### PR TITLE
Maint/ci release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,11 +126,11 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^[0-9]*.[0-9]*.[0-9]*$/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - melodic_release:
           context: ubuntu-pkg-build
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /^[0-9]*.[0-9]*.[0-9]*$/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,38 +32,6 @@ jobs:
             catkin_test_results
     working_directory: ~/src
 
-  lunar:
-    docker:
-      - image: autonomoustuff/docker-builds:lunar-ros-base
-    steps:
-      - checkout
-      - run:
-          name: Set Up Container
-          command: |
-            apt-get update -qq
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            rosdep install --from-paths . --ignore-src -y
-            cd ..
-            catkin init
-            catkin config --extend /opt/ros/$ROS_DISTRO
-      - run:
-          name: Build
-          command: |
-            cd ..
-            catkin build
-      - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
-      - run:
-          name: Run Tests
-          command: |
-            source /opt/ros/lunar/setup.bash
-            cd ..
-            catkin run_tests
-            catkin_test_results
-    working_directory: ~/src
-
   melodic:
     docker:
       - image: autonomoustuff/docker-builds:melodic-ros-base
@@ -120,30 +88,6 @@ jobs:
             deb-s3 upload -b autonomoustuff-ssc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
-  lunar_release:
-    docker:
-      - image: autonomoustuff/docker-builds:lunar-ros-base
-    steps:
-      - checkout
-      - run:
-          name: Set Up Container
-          command: |
-            apt-get update -qq && apt-get install -y dh-make python-bloom ruby
-            gem install --no-rdoc --no-ri deb-s3
-            source `find /opt/ros -name setup.bash | sort | head -1`
-            rosdep install --from-paths . --ignore-src -y
-      - run:
-          name: Build
-          command: |
-            bloom-generate rosdebian --os-name ubuntu --os-version xenial --ros-distro lunar
-            fakeroot debian/rules binary
-      - run:
-          name: Upload
-          command: |
-            cd ..
-            deb-s3 upload -b autonomoustuff-ssc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
-    working_directory: ~/src
-
   melodic_release:
     docker:
       - image: autonomoustuff/docker-builds:melodic-ros-base
@@ -172,32 +116,21 @@ workflows:
   version: 2
   ros_build:
     jobs:
-      - kinetic:
-          filters:
-            branches:
-              ignore: release
-      - lunar:
-          filters:
-            branches:
-              ignore: release
-      - melodic:
-          filters:
-            branches:
-              ignore: release
+      - kinetic
+      - melodic
   ros_release:
     jobs:
       - kinetic_release:
           context: ubuntu-pkg-build
           filters:
             branches:
-              only: release
-      - lunar_release:
-          context: ubuntu-pkg-build
-          filters:
-            branches:
-              only: release
+              ignore: /.*/
+            tags:
+              only: /^[0-9]*.[0-9]*.[0-9]*$/
       - melodic_release:
           context: ubuntu-pkg-build
           filters:
             branches:
-              only: release
+              ignore: /.*/
+            tags:
+              only: /^[0-9]*.[0-9]*.[0-9]*$/


### PR DESCRIPTION
Removes Lunar build (EOL). Sets releases to be defined by tags instead of a release branch.